### PR TITLE
feat: reload systemd for Docker Ubuntu 20 compatibility

### DIFF
--- a/roles/docker/tasks/configure.yml
+++ b/roles/docker/tasks/configure.yml
@@ -17,6 +17,10 @@
 - name: Reset ssh connection to allow user changes to affect current user
   meta: reset_connection
 
+- name: reload systemd
+  command: systemctl daemon-reload
+  when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 20
+
 - name: Start the docker service
   systemd:
     name: docker

--- a/roles/docker/tasks/configure.yml
+++ b/roles/docker/tasks/configure.yml
@@ -19,7 +19,7 @@
 
 - name: reload systemd
   command: systemctl daemon-reload
-  when: ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 20
+  when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version']|int >= 20
 
 - name: Start the docker service
   systemd:


### PR DESCRIPTION
I had to reload systemd to install Docker on Ubuntu 20.04.

Opening this PR here as the original repository seems dead to me. ^^